### PR TITLE
Change folder structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,5 @@ unit-tests:
 	@cd blockfetcher && go test -v
 
 integration-tests:
-	@cd client/fabexclient && go test -v
+	@cd client/ && go test -v
 	@cd ./rest && go test -v

--- a/client/example/client.go
+++ b/client/example/client.go
@@ -18,20 +18,19 @@ package main
 
 import (
 	"fmt"
-	"github.com/hyperledger-labs/fabex/client/fabexclient"
 	pb "github.com/hyperledger-labs/fabex/proto"
 	"log"
 )
 
 var (
-	client *fabexclient.FabexClient
+	client *FabexClient
 	addr   = "0.0.0.0"
 	port   = "6000"
 )
 
 func main() {
 	var err error
-	client, err = fabexclient.New(addr, port)
+	client, err = New(addr, port)
 	if err != nil {
 		panic(err)
 	}

--- a/client/fabex_client.go
+++ b/client/fabex_client.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package fabexclient
+package client
 
 import (
 	"fmt"

--- a/client/fabex_client_test.go
+++ b/client/fabex_client_test.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package fabexclient
+package client
 
 import (
 	"bytes"

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ You can start Fabex as standalone microservice with Cassandra blocks storage:
 
 Use [fabex.proto](https://github.com/hyperledger-labs/fabex/blob/master/proto/fabex.proto) as service contract.
 
-[Example](https://github.com/hyperledger-labs/fabex/blob/master/client/client.go) of GRPC client implementation.
+[Example](https://github.com/hyperledger-labs/fabex/blob/master/client/example/client.go) of GRPC client implementation.
 
 <br><br>
  


### PR DESCRIPTION
- replace example GRPC client to 'example' dir
- rename package 'fabexclient' to 'client' and move to appropriate directory
- fix Makefile and readme