### PR TITLE
Remove troubleshooting section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,25 +106,3 @@ integration tests: `make integration-tests`
 
 <br>
 
-### <a name="troubleshooting">Troubleshooting</a>
-
-Error:
-```
-# github.com/hyperledger/fabric-sdk-go/internal/github.com/hyperledger/fabric/core/operations
-../../../../pkg/mod/github.com/hyperledger/fabric-sdk-go@v0.0.0-20190306235112-f198238ee7da/internal/github.com/hyperledger/fabric/core/operations/system.go:227:23: not enough arguments in call to s.statsd.SendLoop
- have (<-chan time.Time, string, string)
- want (context.Context, <-chan time.Time, string, string)
-```
-It's known issue [FABG-885](https://jira.hyperledger.org/browse/FABG-885)
-
-Solution:
-
-open SDK file `$GOPATH/pkg/mod/github.com/hyperledger/fabric-sdk-go@v0.0.0-20190306235112-f198238ee7da/internal/github.com/hyperledger/fabric/core/operations/system.go`
-
-on the line 227 replace this:
-
-`go s.statsd.SendLoop(s.sendTicker.C, network, address)`
-
-to:
-
-`go s.statsd.SendLoop(context.Background(), s.sendTicker.C, network, address)`


### PR DESCRIPTION
Since we can downgrade goSDK to alpha4 thus preventing breaking API
change and avoiding compilation error troubleshooting section could be
removed.

Signed-off-by: Artem Barger <bartem@il.ibm.com>